### PR TITLE
Add support for amplitude control under Android 8.0 and later

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ introduced in Android 8.0 Oreo - false for all earlier API levels.
 
 ``` dart
 if (Vibration.hasAmplitudeControl()) {
-    // Vibrate with effect
+    Vibration.vibrate(amplitude: 128);
 }
 ```
 
@@ -52,10 +52,22 @@ Vibration.vibrate(duration: 1000);
 
 Default duration is 500ms. 
 
-#### With pattern (wait 500ms, vibrate 1s, waint 500ms):
+#### With specific duration and specific amplitude (if supported):
 
 ``` dart
-Vibration.vibrate(pattern: [500, 1000, 500]);
+Vibration.vibrate(duration: 1000, amplitude: 128);
+```
+
+#### With pattern (wait 500ms, vibrate 1s, wait 500ms, vibrate 2s):
+
+``` dart
+Vibration.vibrate(pattern: [500, 1000, 500, 2000]);
+```
+
+#### With pattern (wait 500ms, vibrate 1s, wait 500ms, vibrate 2s) at varying intensities (1 - min, 255 - max):
+
+``` dart
+Vibration.vibrate(pattern: [500, 1000, 500, 2000], intensities: [1, 255]);
 ```
 
 ### cancel

--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ if (Vibration.hasVibrator()) {
 }
 ```
 
+### hasAmplitudeControl
+
+Check if the target device has the ability to control the vibration amplitude,
+introduced in Android 8.0 Oreo - false for all earlier API levels.
+
+``` dart
+if (Vibration.hasAmplitudeControl()) {
+    // Vibrate with effect
+}
+```
+
 ### vibrate
 
 #### With specific duration (for example, 1 second):

--- a/android/src/main/java/com/benjaminabel/vibration/VibrationPlugin.java
+++ b/android/src/main/java/com/benjaminabel/vibration/VibrationPlugin.java
@@ -59,6 +59,17 @@ public class VibrationPlugin implements MethodCallHandler {
             result.success(vibrator.hasVibrator());
 
             break;
+        case "hasAmplitudeControl":
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                result.success(vibrator.hasAmplitudeControl());
+            } else {
+                // For earlier API levels, return false rather than raising a
+                // MissingPluginException in order to allow applications to handle
+                // non-existence gracefully.
+                result.success(false);
+            }
+
+            break;
         case "vibrate":
             int duration = call.argument("duration");
             List<Integer> pattern = call.argument("pattern");

--- a/ios/Classes/SwiftVibrationPlugin.swift
+++ b/ios/Classes/SwiftVibrationPlugin.swift
@@ -15,6 +15,8 @@ public class SwiftVibrationPlugin: NSObject, FlutterPlugin {
         switch (call.method) {
         case "hasVibrator":
             result(isDevice)
+	case "hasAmplitudeControl":
+            result(isDevice)
         case "vibrate":
             AudioServicesPlaySystemSound(kSystemSoundID_Vibrate)
             result(nil)

--- a/lib/vibration.dart
+++ b/lib/vibration.dart
@@ -16,6 +16,10 @@ class Vibration {
   /// ```
   static Future hasVibrator() => _channel.invokeMethod("hasVibrator");
 
+  /// Check if the vibrator has amplitude control.
+  static Future hasAmplitudeControl() =>
+      _channel.invokeMethod("hasAmplitudeControl");
+
   /// Vibrate with [duration] or [pattern].
   /// The default vibration duration is 500ms.
   /// 

--- a/lib/vibration.dart
+++ b/lib/vibration.dart
@@ -17,21 +17,37 @@ class Vibration {
   static Future hasVibrator() => _channel.invokeMethod("hasVibrator");
 
   /// Check if the vibrator has amplitude control.
+  ///
+  /// ```dart
+  /// if (Vibration.hasAmplitudeControl()) {
+  ///   Vibration.vibrate(amplitude: 128);
+  /// }
+  /// ```
   static Future hasAmplitudeControl() =>
       _channel.invokeMethod("hasAmplitudeControl");
 
-  /// Vibrate with [duration] or [pattern].
+  /// Vibrate with [duration] at [amplitude] or [pattern] at [intensities].
+  ///
   /// The default vibration duration is 500ms.
+  /// Amplitude is a range from 1 to 255, if supported.
   /// 
   /// ```dart
   /// Vibration.vibrate(duration: 1000);
+  ///
+  /// if (Vibration.hasAmplitudeControl()) {
+  ///   Vibration.vibrate(duration: 1000, amplitude: 1);
+  ///   Vibration.vibrate(duration: 1000, amplitude: 255);
+  /// }
   /// ```
   static Future<void> vibrate(
           {int duration = 500,
           List<int> pattern = const [],
-          int repeat = -1}) =>
+          int repeat = -1,
+          List<int> intensities = const [],
+          int amplitude = -1}) =>
       _channel.invokeMethod("vibrate",
-          {"duration": duration, "pattern": pattern, "repeat": repeat});
+          {"duration": duration, "pattern": pattern, "repeat": repeat,
+           "amplitude": amplitude, "intensities": intensities});
 
   /// Cancel ongoing vibration.
   /// 


### PR DESCRIPTION
Newer API levels (from 26 on) support determining amplitude control capability and varying the amplitude of vibrations, both in one-shot and in waveform-based patterns. This adds basic support for working with these aspects while: (1) providing a safe default for devices on earlier API levels (which notice no change in behaviour); and (2) enabling apps to begin future-proofing for newer API levels by testing the control capability.