### PR TITLE
Added a `hasCustomVibrationsSupport` method (fixes #34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,23 @@ if (await Vibration.hasAmplitudeControl()) {
 }
 ```
 
+### hasCustomVibrationsSupport
+
+Check if the device is able to vibrate with a custom duration, pattern or intensity.
+May return `true` even if the device has no vibrator (if you want to check whether the device has a vibrator,
+see [`hasVibrator`](#hasvibrator)).
+
+```dart
+if (await Vibration.hasCustomVibrationsSupport()) {
+    Vibration.vibrate(duration: 1000);
+}
+else {
+    Vibration.vibrate();
+    await Future.delayed(Duration(milliseconds: 500));
+    Vibration.vibrate();
+}
+```
+
 ### vibrate
 
 #### With specific duration (for example, 1 second):
@@ -92,3 +109,4 @@ For the rest of the usage instructions, see [Vibrator](https://developer.android
 ## iOS
 
 Supports vibration with duration and pattern on CoreHaptics devices. On older devices, the pattern is emulated with 500ms long vibrations.
+You can check whether the device has CoreHaptics support using [`hasCustomVibrationsSupport`](#hasCustomVibrationsSupport).

--- a/README.md
+++ b/README.md
@@ -109,4 +109,4 @@ For the rest of the usage instructions, see [Vibrator](https://developer.android
 ## iOS
 
 Supports vibration with duration and pattern on CoreHaptics devices. On older devices, the pattern is emulated with 500ms long vibrations.
-You can check whether the device has CoreHaptics support using [`hasCustomVibrationsSupport`](#hasCustomVibrationsSupport).
+You can check whether the current device has CoreHaptics support using [`hasCustomVibrationsSupport`](#hasCustomVibrationsSupport).

--- a/android/src/main/java/com/benjaminabel/vibration/VibrationPlugin.java
+++ b/android/src/main/java/com/benjaminabel/vibration/VibrationPlugin.java
@@ -102,6 +102,9 @@ public class VibrationPlugin implements MethodCallHandler {
             }
 
             break;
+        case "hasCustomVibrationsSupport":
+            result.success(true);
+            break;
         case "vibrate":
             int duration = call.argument("duration");
             List<Integer> pattern = call.argument("pattern");

--- a/ios/Classes/SwiftVibrationPlugin.swift
+++ b/ios/Classes/SwiftVibrationPlugin.swift
@@ -66,6 +66,8 @@ public class SwiftVibrationPlugin: NSObject, FlutterPlugin {
             result(isDevice)
         case "hasAmplitudeControl":
             result(isDevice)
+        case "hasCustomVibrationsSupport":
+            result(CHHapticEngine.capabilitiesForHardware().supportsHaptics)
         case "vibrate":
             guard let args = call.arguments else {
                 result(isDevice)

--- a/lib/vibration.dart
+++ b/lib/vibration.dart
@@ -26,6 +26,23 @@ class Vibration {
   static Future<bool> hasAmplitudeControl() =>
       _channel.invokeMethod("hasAmplitudeControl");
 
+  /// Check if the device is able to vibrate with a custom
+  /// [duration], [pattern] or [intensities].
+  /// May return `true` even if the device has no vibrator.
+  ///
+  /// ```dart
+  /// if (await Vibration.hasCustomVibrationsSupport()) {
+  ///   Vibration.vibrate(duration: 1000);
+  /// }
+  /// else {
+  ///   Vibration.vibrate();
+  ///   await Future.delayed(Duration(milliseconds: 500));
+  ///   Vibration.vibrate();
+  /// }
+  /// ```
+  static Future<bool> hasCustomVibrationsSupport() =>
+      _channel.invokeMethod("hasCustomVibrationsSupport");
+
   /// Vibrate with [duration] at [amplitude] or [pattern] at [intensities].
   ///
   /// The default vibration duration is 500ms.


### PR DESCRIPTION
Added a `hasCustomVibrationsSupport` method that allows to have a better control on what devices are able to have custom vibratations (longer / shorter, custom patterns, ...).

See #34. 