### PR TITLE
Fix compatiable with swift project. 

### DIFF
--- a/vibration/ios/Classes/VibrationPlugin.m
+++ b/vibration/ios/Classes/VibrationPlugin.m
@@ -1,5 +1,9 @@
 #import "VibrationPlugin.h"
+#if __has_include(<vibration/vibration-Swift.h>)
 #import <vibration/vibration-Swift.h>
+#else
+#import "vibration-Swift.h"
+#endif
 
 @implementation VibrationPlugin
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {


### PR DESCRIPTION
The generated compatibility header is not copied to header search path in swift project.