### PR TITLE
Adds Android namespace

### DIFF
--- a/vibration/CHANGELOG.md
+++ b/vibration/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.7.7
+- Adds a namespace attribute to the Android build.gradle, for compatibility with Android Gradle Plugin 8.0.
+
 ## 1.7.6
 - Update package's dart SDK max version (under 3.0.0)
 

--- a/vibration/android/build.gradle
+++ b/vibration/android/build.gradle
@@ -22,6 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.benjaminabel.vibration'
     compileSdkVersion 28
 
     defaultConfig {

--- a/vibration/example/android/app/build.gradle
+++ b/vibration/example/android/app/build.gradle
@@ -25,6 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace 'com.benjaminabel.vibration_example'
     compileSdkVersion 28
 
     lintOptions {

--- a/vibration/pubspec.yaml
+++ b/vibration/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vibration
 description: A plugin for handling Vibration API on iOS, Android, and web.
-version: 1.7.6
+version: 1.7.7
 homepage: https://github.com/benjamindean/flutter_vibration
 
 environment:


### PR DESCRIPTION
Adds a namespace attribute to the Android build.gradle, for compatibility with Android Gradle Plugin 8.0.
See:
https://github.com/flutter/packages/commit/6284c2d4e46a5d289e77cb03a9457543b97f750b