### PR TITLE
On ios play default vibration when failed to play pattern

### DIFF
--- a/vibration/ios/Classes/VibrationPluginSwift.swift
+++ b/vibration/ios/Classes/VibrationPluginSwift.swift
@@ -110,7 +110,8 @@ public class VibrationPluginSwift: NSObject, FlutterPlugin {
                 try player.start(atTime: 0)
             }
         } catch {
-            print("Failed to play pattern: \(error.localizedDescription).")
+            print("Failed to play pattern: \(error.localizedDescription). Play default.")
+            AudioServicesPlaySystemSound(kSystemSoundID_Vibrate)
         }
     }
     @available(iOS 13.0, *)
@@ -118,8 +119,6 @@ public class VibrationPluginSwift: NSObject, FlutterPlugin {
         VibrationPluginSwift.engine?.stop(completionHandler: { error in
             if let error = error {
                 print("Error stopping haptic engine: \(error)")
-            } else {
-                print("Haptic engine stopped successfully.")
             }
         })
     }


### PR DESCRIPTION
Play the default vibration when unable to play a custom pattern.

For example if the core haptic engine is stopped because the app is in the background.

In my opinion, it's a good practice to trigger the default vibration when you can't use a specific pattern.

PS.
Playing vibrations using the core haptic engine is not possible when the app is in the background. You can refer to this [forum discussion](https://developer.apple.com/forums/thread/676629) and the [Apple documentation](https://developer.apple.com/documentation/corehaptics/preparing_your_app_to_play_haptics#3200014) for more information.
