### PR TITLE
fix: deprecation warning

### DIFF
--- a/vibration/CHANGELOG.md
+++ b/vibration/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.8.3
+## 1.8.4
 
 - Added Web support (#95 by [san-smith](https://github.com/san-smith))
 

--- a/vibration/android/src/main/java/com/benjaminabel/vibration/VibrationPlugin.java
+++ b/vibration/android/src/main/java/com/benjaminabel/vibration/VibrationPlugin.java
@@ -1,7 +1,9 @@
 package com.benjaminabel.vibration;
 
 import android.content.Context;
+import android.os.Build;
 import android.os.Vibrator;
+import android.os.VibratorManager;
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.BinaryMessenger;
@@ -29,7 +31,13 @@ public class VibrationPlugin implements FlutterPlugin {
     }
 
     private void setupChannels(BinaryMessenger messenger, Context context) {
-        final Vibrator vibrator = (Vibrator) context.getSystemService(Context.VIBRATOR_SERVICE);
+        Vibrator vibrator;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            VibratorManager vibratorManager = (VibratorManager) context.getSystemService(Context.VIBRATOR_MANAGER_SERVICE);
+            vibrator = vibratorManager.getDefaultVibrator();
+        } else {
+            vibrator = (Vibrator) context.getSystemService(Context.VIBRATOR_SERVICE);
+        }
         final VibrationMethodChannelHandler methodChannelHandler = new VibrationMethodChannelHandler(new Vibration(vibrator));
 
         this.methodChannel = new MethodChannel(messenger, CHANNEL);


### PR DESCRIPTION
#87
Using this stackoverflow solves the deprecation warning: https://stackoverflow.com/questions/68466095/vibrator-service-string-is-deprecated-for-api-31 (converted it to java)