### PR TITLE
refactor: migrate from dart:js to web package

### DIFF
--- a/vibration_web/CHANGELOG.md
+++ b/vibration_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.6.7
+
+- Migrate from dart:js to web package for Wasm support (#102 by [san-smith](https://github.com/san-smith))
+
 ## 1.6.6
 
 - Added Web support (#95 by [san-smith](https://github.com/san-smith))

--- a/vibration_web/lib/vibration_web.dart
+++ b/vibration_web/lib/vibration_web.dart
@@ -1,12 +1,14 @@
 import 'dart:async';
-import 'dart:js';
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
 
 import 'package:flutter/services.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+import 'package:web/web.dart' as web;
 
 class VibrationWebPlugin {
   /// Get navigator JS object
-  static final _navigator = context['navigator'];
+  static final _navigator = web.window.navigator;
 
   static void registerWith(Registrar registrar) {
     final MethodChannel channel = MethodChannel(
@@ -46,16 +48,17 @@ class VibrationWebPlugin {
 
   static bool _hasVibrator() {
     /// Check if the navigator object has the vibrate function
-    return _navigator.hasProperty('vibrate');
+    return _navigator.has('vibrate');
   }
 
   static _vibrate({int duration = 500, List<int> pattern = const []}) {
     if (_hasVibrator()) {
       /// If pattern is not empty, convert to JS array
-      final args = pattern.length > 0 ? JsArray.from(pattern) : duration;
+      final args =
+          pattern.length > 0 ? pattern.jsify() ?? duration.toJS : duration.toJS;
 
       /// Call vibrate function
-      _navigator.callMethod('vibrate', [args]);
+      _navigator.vibrate(args);
     }
   }
 

--- a/vibration_web/pubspec.yaml
+++ b/vibration_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vibration_web
 description: A plugin for handling Vibration API on the Web
-version: 1.6.6
+version: 1.6.7
 homepage: https://github.com/benjamindean/flutter_vibration
 
 environment:

--- a/vibration_web/pubspec.yaml
+++ b/vibration_web/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.6.6
 homepage: https://github.com/benjamindean/flutter_vibration
 
 environment:
-  sdk: ">=2.12.1 <3.0.0"
+  sdk: ">=3.3.0 <4.0.0"
   flutter: ">=1.20.0"
 
 dependencies:
@@ -12,6 +12,8 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
+  
+  web: ^0.5.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Hi, this is necessary to support Wasm in Flutter apps:
https://docs.flutter.dev/platform-integration/web/wasm