### PR TITLE
chore: lower compileSdk to 34 from 35

### DIFF
--- a/vibration/android/build.gradle
+++ b/vibration/android/build.gradle
@@ -24,7 +24,7 @@ apply plugin: "com.android.library"
 android {
     namespace = "com.benjaminabel.vibration"
 
-    compileSdk = 35
+    compileSdk = 34
 
     gradle.projectsEvaluated {
         tasks.withType(JavaCompile) {


### PR DESCRIPTION
Lowering compile SDK constraint to allow to be used in apps targeting SDK 34

fixes #126