### PR TITLE
kSystemSoundID_Vibrate when haptics not available

### DIFF
--- a/vibration/ios/Classes/VibrationPluginSwift.swift
+++ b/vibration/ios/Classes/VibrationPluginSwift.swift
@@ -151,7 +151,7 @@ public class VibrationPluginSwift: NSObject, FlutterPlugin {
                 try player.start(atTime: 0)
             }
         } catch {
-            print("Failed to play pattern: \(error.localizedDescription).")
+            AudioServicesPlaySystemSound(kSystemSoundID_Vibrate)
         }
     }
 


### PR DESCRIPTION
Haptics not work when screen is locked, as mentioned in #94 which is not merged.
So, play kSystemSoundID_Vibrate, when haptic engine not works.