### PR TITLE
Bump Versions for device_info_plus 12.x support

### DIFF
--- a/vibration/CHANGELOG.md
+++ b/vibration/CHANGELOG.md
@@ -1,3 +1,14 @@
+### 3.1.4
+
+> Note: This release has breaking changes.
+>
+> Plugin now requires the following:
+> - Android Gradle Plugin >=8.12.1
+> - Gradle wrapper >=8.13
+> - Kotlin 2.2.0
+
+- Bump package `vibration_platform_interface` to "0.1.1"
+
 ### 3.1.3
 
 - Fix intensities on iOS.

--- a/vibration/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/vibration/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip

--- a/vibration/example/android/settings.gradle
+++ b/vibration/example/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.3.1" apply false
-    id "org.jetbrains.kotlin.android" version "2.0.20" apply false
+    id "com.android.application" version "8.12.1" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.0" apply false
 }
 
 include ":app"

--- a/vibration/pubspec.yaml
+++ b/vibration/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vibration
 description: A plugin for handling Vibration API on iOS, Android, web and OpenHarmony.
-version: 3.1.3
+version: 3.1.4
 homepage: https://github.com/benjamindean/flutter_vibration
 
 environment:
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.0.2
-  vibration_platform_interface: ^0.1.0
+  vibration_platform_interface: ^0.1.1
 
 dev_dependencies:
   flutter_test:

--- a/vibration/test/vibration_test.dart
+++ b/vibration/test/vibration_test.dart
@@ -107,7 +107,8 @@ void main() {
             'pattern': [],
             'repeat': -1,
             'amplitude': -1,
-            'intensities': []
+            'intensities': [],
+            'sharpness': 0.5,
           })
         ],
       );
@@ -127,7 +128,8 @@ void main() {
             'pattern': [100, 200, 400],
             'repeat': 1,
             'amplitude': -1,
-            'intensities': []
+            'intensities': [],
+            'sharpness': 0.5,
           })
         ],
       );

--- a/vibration_ohos/CHANGELOG.md
+++ b/vibration_ohos/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.4
+
+* Bump package `device_info_plus_ohos` to "0.0.8"
+* Bump package `vibration_platform_interface` to "0.1.1"
+
 ## 0.0.3
 
 * Update vibration_platform_interface

--- a/vibration_ohos/CHANGELOG.md
+++ b/vibration_ohos/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.0.4
 
-* Bump package `device_info_plus_ohos` to "0.0.8"
+* Bump package `device_info_plus_ohos` to ">=0.0.7 <1.0.0"
 * Bump package `vibration_platform_interface` to "0.1.1"
 
 ## 0.0.3

--- a/vibration_ohos/pubspec.yaml
+++ b/vibration_ohos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vibration_ohos
 description: The OpenHarmony implementation of vibration.
-version: 0.0.3
+version: 0.0.4
 homepage: https://github.com/benjamindean/flutter_vibration
 
 environment:
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  vibration_platform_interface: ^0.0.3
-  device_info_plus_ohos: ^0.0.7
+  vibration_platform_interface: ^0.1.1
+  device_info_plus_ohos: ^0.0.8
 
 # dependency_overrides:
 #   vibration_platform_interface:

--- a/vibration_ohos/pubspec.yaml
+++ b/vibration_ohos/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   vibration_platform_interface: ^0.1.1
-  device_info_plus_ohos: ^0.0.8
+  device_info_plus_ohos: ">=0.0.7 <1.0.0"
 
 # dependency_overrides:
 #   vibration_platform_interface:

--- a/vibration_platform_interface/CHANGELOG.md
+++ b/vibration_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+- Bump package `device_info_plus` to ">=9.0.2 <13.0.0"
+
 ## 0.1.0
 
 - Add sharpness parameter for iOS.

--- a/vibration_platform_interface/pubspec.yaml
+++ b/vibration_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vibration_platform_interface
 description: A common platform interface for the vibration plugin.
-version: 0.1.0
+version: 0.1.1
 homepage: https://github.com/benjamindean/flutter_vibration
 
 environment:
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.1.4
-  device_info_plus: ">=9.0.2 <12.0.0"
+  device_info_plus: ">=9.0.2 <13.0.0"
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
chore(vibration): bump version to 3.1.4
- Bump `vibration_platform_interface` to "0.1.1"
- Update example: Kotlin -> "2.2.0", AGP -> "8.12.1" (note: build tool break)
- Update tests to include `sharpness` param
-----
chore(vibration_ohos): bump version to 0.0.4
- Bump `device_info_plus_ohos` dependency to ">=0.0.7 <1.0.0"
- Bump `vibration_platform_interface` dependency to "0.1.1"
-----
chore(vibration_platform_interface): bump version to 0.1.1
- Bump `device_info_plus` dependency range to ">=9.0.2 <13.0.0" to allow 12.x
