### PR TITLE
fix: 145 repeat ignored on ios

### DIFF
--- a/vibration/ios/vibration/Sources/vibration/VibrationPlugin.swift
+++ b/vibration/ios/vibration/Sources/vibration/VibrationPlugin.swift
@@ -13,6 +13,12 @@ public class VibrationPlugin: NSObject, FlutterPlugin {
     @available(iOS 13.0, *)
     public static var engine: CHHapticEngine?
 
+    /// Monotonically-increasing counter used to invalidate in-flight repeat closures.
+    /// Incrementing this value causes any `scheduleRepeat` closure that captured an older
+    /// generation to exit without playing, effectively cancelling the active loop.
+    @available(iOS 13.0, *)
+    private static var repeatGeneration: Int = 0
+
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "vibration", binaryMessenger: registrar.messenger())
         let instance = VibrationPlugin()
@@ -39,8 +45,13 @@ public class VibrationPlugin: NSObject, FlutterPlugin {
         }
 
         // The stopped handler alerts you of engine stoppage due to external causes.
+        // Cancel any active repeat loop for all stop reasons except .notifyWhenFinished,
+        // which is an intentional completion and not applicable to our usage.
         VibrationPlugin.engine?.stoppedHandler = { reason in
             print("The engine stopped for reason: \(reason.rawValue)")
+            if reason != .notifyWhenFinished {
+                VibrationPlugin.repeatGeneration += 1
+            }
         }
 
         // The reset handler provides an opportunity for your app to restart the engine in case of failure.
@@ -114,16 +125,33 @@ public class VibrationPlugin: NSObject, FlutterPlugin {
         return myArgs["sharpness"] as? Float ?? 0.5
     }
 
-    @available(iOS 13.0, *)
-    private func playPattern(myArgs: [String: Any]) -> Void {
-        let intensities = getIntensities(myArgs: myArgs)
-        let patternArray = getPattern(myArgs: myArgs)
-        let sharpness = getSharpness(myArgs: myArgs)
+    /// Returns the repeat index from the method arguments, defaulting to `-1` (no repeat).
+    /// A value of `0` loops the entire pattern; a value of `N` plays the full pattern once,
+    /// then loops from index `N` onward on every subsequent iteration.
+    private func getRepeat(myArgs: [String: Any]) -> Int {
+        return myArgs["repeat"] as? Int ?? -1
+    }
 
+    /// Builds an array of `CHHapticEvent` values from a slice of the pattern.
+    ///
+    /// - Parameters:
+    ///   - pattern: Timing values in milliseconds, alternating silence and vibration durations.
+    ///   - intensities: Amplitude values (0–255) corresponding to each element in `pattern`.
+    ///   - sharpness: Haptic sharpness applied to all vibration events.
+    ///   - startIndex: Index into `pattern` and `intensities` to begin from. Defaults to `0`
+    ///                 (full pattern). Pass `repeatIndex` here when building loop-slice events.
+    @available(iOS 13.0, *)
+    private func buildHapticEvents(
+        pattern: [Int],
+        intensities: [Int],
+        sharpness: Float,
+        startIndex: Int = 0
+    ) -> [CHHapticEvent] {
         var hapticEvents: [CHHapticEvent] = []
         var rel: Double = 0.0
 
-        for (i, duration) in patternArray.enumerated() {
+        for i in startIndex..<pattern.count {
+            let duration = pattern[i]
             if intensities[i] != 0 {
                 hapticEvents.append(
                     CHHapticEvent(
@@ -136,27 +164,113 @@ public class VibrationPlugin: NSObject, FlutterPlugin {
                         duration: Double(duration) / 1000.0
                     )
                 )
-
-                rel += Double(duration) / 1000.0
-            } else {
-                rel += Double(duration) / 1000.0
             }
+            rel += Double(duration) / 1000.0
         }
 
-        do {
-            if let engine = VibrationPlugin.engine {
-                let patternToPlay = try CHHapticPattern(events: hapticEvents, parameters: [])
-                let player = try engine.makePlayer(with: patternToPlay)
-                try engine.start()
-                try player.start(atTime: 0)
+        return hapticEvents
+    }
+
+    /// Submits a set of haptic events to the shared engine and starts playback immediately.
+    @available(iOS 13.0, *)
+    private func playHapticEvents(_ events: [CHHapticEvent]) throws {
+        if let engine = VibrationPlugin.engine {
+            let patternToPlay = try CHHapticPattern(events: events, parameters: [])
+            let player = try engine.makePlayer(with: patternToPlay)
+            try engine.start()
+            try player.start(atTime: 0)
+        }
+    }
+
+    /// Schedules one loop iteration after `afterMs` milliseconds, then reschedules itself.
+    ///
+    /// Before each iteration the closure checks `VibrationPlugin.repeatGeneration` against
+    /// the captured `generation`. If they differ — because `cancelVibration` or a new
+    /// `playPattern` call incremented the counter — the closure exits without playing or
+    /// rescheduling, ending the loop.
+    ///
+    /// - Parameters:
+    ///   - pattern: Full pattern array (only the slice from `startIndex` onward is played).
+    ///   - intensities: Amplitude values corresponding to each element in `pattern`.
+    ///   - sharpness: Haptic sharpness forwarded to `buildHapticEvents`.
+    ///   - startIndex: Index in `pattern` at which each iteration begins.
+    ///   - loopSliceMs: Duration of one loop iteration in milliseconds; reused as the delay
+    ///                  before the next iteration.
+    ///   - generation: The `repeatGeneration` value captured when this repeat session started.
+    ///   - afterMs: Delay in milliseconds before the current iteration fires.
+    @available(iOS 13.0, *)
+    private func scheduleRepeat(
+        pattern: [Int],
+        intensities: [Int],
+        sharpness: Float,
+        startIndex: Int,
+        loopSliceMs: Int,
+        generation: Int,
+        afterMs: Int
+    ) {
+        DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(afterMs)) { [weak self] in
+            guard let self = self,
+                  VibrationPlugin.repeatGeneration == generation else { return }
+            do {
+                let loopEvents = self.buildHapticEvents(
+                    pattern: pattern,
+                    intensities: intensities,
+                    sharpness: sharpness,
+                    startIndex: startIndex
+                )
+                try self.playHapticEvents(loopEvents)
+            } catch {
+                print("Failed to play repeat loop: \(error.localizedDescription).")
+                return
             }
-        } catch {
-            print("Failed to play pattern: \(error.localizedDescription).")
+            self.scheduleRepeat(
+                pattern: pattern,
+                intensities: intensities,
+                sharpness: sharpness,
+                startIndex: startIndex,
+                loopSliceMs: loopSliceMs,
+                generation: generation,
+                afterMs: loopSliceMs
+            )
         }
     }
 
     @available(iOS 13.0, *)
+    private func playPattern(myArgs: [String: Any]) -> Void {
+        let intensities = getIntensities(myArgs: myArgs)
+        let patternArray = getPattern(myArgs: myArgs)
+        let sharpness = getSharpness(myArgs: myArgs)
+        let repeatIndex = getRepeat(myArgs: myArgs)
+
+        do {
+            let events = buildHapticEvents(pattern: patternArray, intensities: intensities, sharpness: sharpness)
+            try playHapticEvents(events)
+        } catch {
+            print("Failed to play pattern: \(error.localizedDescription).")
+            return
+        }
+
+        guard repeatIndex >= 0, repeatIndex < patternArray.count else { return }
+
+        VibrationPlugin.repeatGeneration += 1
+        let gen = VibrationPlugin.repeatGeneration
+        let firstPlayMs = patternArray.reduce(0, +)
+        let loopSliceMs = patternArray[repeatIndex...].reduce(0, +)
+
+        scheduleRepeat(
+            pattern: patternArray,
+            intensities: intensities,
+            sharpness: sharpness,
+            startIndex: repeatIndex,
+            loopSliceMs: loopSliceMs,
+            generation: gen,
+            afterMs: firstPlayMs
+        )
+    }
+
+    @available(iOS 13.0, *)
     private func cancelVibration() {
+        VibrationPlugin.repeatGeneration += 1
         VibrationPlugin.engine?.stop(completionHandler: { error in
             if let error = error {
                 print("Error stopping haptic engine: \(error)")


### PR DESCRIPTION
## Description

Fixes: #145 

Implements a plugin-managed repeat loop on iOS that matches Android semantics:

- **Full pattern once, then loop from index `repeat` onward**: `repeat: 0` loops the entire pattern; `repeat: N` plays all elements once, then repeats from element N.
- **Cancellation via a generation counter**: `repeatGeneration` is incremented by `cancelVibration()` and by the engine's `stoppedHandler` (all stop reasons except `.notifyWhenFinished`). Any in-flight `scheduleRepeat` closure that detects a stale generation exits immediately, covering manual cancel, phone calls, app suspension, and system errors.
- **No API changes**: the existing `repeat` parameter contract is preserved; `repeat: -1` (default) continues to play once with no change in behaviour.

Additionally, documented the code.

### Test
Device: iPhone 14 ProMax
iOS: 26.2.1
