### PR TITLE
Add FlutterFramework SwiftPM dep

### DIFF
--- a/vibration/CHANGELOG.md
+++ b/vibration/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 3.1.9
+
+- Adds missing `FlutterFramework` dependency to `Package.swift` for Swift Package Manager compatibility.
+
 ### 3.1.8
 
 - Fix `repeat` parameter ignored on iOS. (#145 by @zeienko-vitalii)

--- a/vibration/CHANGELOG.md
+++ b/vibration/CHANGELOG.md
@@ -1,4 +1,11 @@
-### 3.1.9
+### 3.2.0
+
+> Note: This release has breaking changes.
+>
+> Plugin now requires the following:
+>
+> - Dart SDK >=3.11.0
+> - Flutter >=3.41.0
 
 - Adds missing `FlutterFramework` dependency to `Package.swift` for Swift Package Manager compatibility.
 

--- a/vibration/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/vibration/example/ios/Flutter/AppFrameworkInfo.plist
@@ -20,7 +20,5 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>MinimumOSVersion</key>
-  <string>13.0</string>
 </dict>
 </plist>

--- a/vibration/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/vibration/example/ios/Runner.xcodeproj/project.pbxproj
@@ -57,6 +57,8 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		784666492D4C4C64000A1A5F /* FlutterFramework */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterFramework; path = Flutter/ephemeral/Packages/.packages/FlutterFramework; sourceTree = "<group>"; };
+		78DABEA22ED26510000E7860 /* vibration */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = vibration; path = ../../ios/vibration; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -89,6 +91,8 @@
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
+				78DABEA22ED26510000E7860 /* vibration */,
+				784666492D4C4C64000A1A5F /* FlutterFramework */,
 				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
 				9740EEB21CF90195004384FC /* Debug.xcconfig */,

--- a/vibration/example/pubspec.yaml
+++ b/vibration/example/pubspec.yaml
@@ -19,7 +19,8 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.11.0
+  flutter: ">=3.41.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/vibration/ios/vibration/Package.swift
+++ b/vibration/ios/vibration/Package.swift
@@ -11,11 +11,15 @@ let package = Package(
     products: [
         .library(name: "vibration", targets: ["vibration"])
     ],
-    dependencies: [],
+    dependencies: [
+        .package(name: "FlutterFramework", path: "../FlutterFramework")
+    ],
     targets: [
         .target(
             name: "vibration",
-            dependencies: [],
+            dependencies: [
+                .product(name: "FlutterFramework", package: "FlutterFramework")
+            ],
             resources: [
                 .process("Resources/PrivacyInfo.xcprivacy"),
             ]

--- a/vibration/pubspec.yaml
+++ b/vibration/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vibration
 description: A plugin for handling Vibration API on iOS, Android, web and OpenHarmony.
-version: 3.1.8
+version: 3.1.9
 homepage: https://github.com/benjamindean/flutter_vibration
 
 environment:

--- a/vibration/pubspec.yaml
+++ b/vibration/pubspec.yaml
@@ -1,11 +1,11 @@
 name: vibration
 description: A plugin for handling Vibration API on iOS, Android, web and OpenHarmony.
-version: 3.1.9
+version: 3.2.0
 homepage: https://github.com/benjamindean/flutter_vibration
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ^3.11.0
+  flutter: ">=3.41.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
### DESCRIPTION

- There's a new section into the [migration guide](https://docs.flutter.dev/packages-and-plugins/swift-package-manager/for-plugin-authors#how-to-add-swift-package-manager-support-to-an-existing-flutter-plugin). Now, adding `FlutterFramework` dependency is required to avoid a new warning.
